### PR TITLE
fix: Foi necessário corrigir nome da imagem

### DIFF
--- a/packer/source.pkr.hcl
+++ b/packer/source.pkr.hcl
@@ -8,5 +8,5 @@ source "googlecompute" "imagem-base-orquestradores" {
   ssh_username        = var.config_gcp.usuario_ssh
   zone                = var.config_gcp.zona
 
-  image_name = "orquestradores-${local.image_id}"
+  image_name = regex_replace("orquestradores-${local.image_id}", ".", "-")
 }

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+orquestradores-v0.0.4


### PR DESCRIPTION
Devido a regras da gcp foi necessário fazer um replace no nome da imagem
para remover os pontos gerados pela tag de release.

Revisor por:
- Danilo Rocha
- Luiz Aoqui
- Thais d'Angelis
- Karollyne Costa
- Mansur
- Raph

Ref: mentoriaiac#5 mentoriaiac#6 mentoriaiac#9